### PR TITLE
Merge pull request #94 from rectorphp/bootstrap-style

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -342,7 +342,7 @@ h1 em, h2 em, h2 a {
 }
 
 #demo {
-    min-height: 20em;
+    min-height: 36em;
 
     &.short {
         min-height: 12em;
@@ -354,7 +354,7 @@ h1 em, h2 em, h2 a {
     background: #666;
 
     h2, h3 {
-        color: #DDD;
+        color: #fcf8e3;
     }
 }
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -3,6 +3,17 @@ parameters:
     host_demo_dir: '%env(HOST_DEMO_DIR)%'
     rector_demo_docker_image: 'rector/rector:0.6.11'
 
+    demo_links:
+        -
+            label: "PHP 7.4 Typed Properties"
+            uuid:
+        -
+            label: "create_function()"
+            uuid:
+        -
+            label: "Add @var type"
+            uuid:
+
 services:
     _defaults:
         public: true

--- a/src/Controller/DemoController.php
+++ b/src/Controller/DemoController.php
@@ -22,6 +22,11 @@ use Symfony\Component\Routing\Annotation\Route;
 final class DemoController extends AbstractController
 {
     /**
+     * @var string[][]
+     */
+    private $demoLinks = [];
+
+    /**
      * @var RectorRunRepository
      */
     private $rectorRunRepository;
@@ -31,10 +36,14 @@ final class DemoController extends AbstractController
      */
     private $demoRunner;
 
-    public function __construct(RectorRunRepository $rectorRunRepository, DemoRunner $demoRunner)
+    /**
+     * @param string[][] $demoLinks
+     */
+    public function __construct(RectorRunRepository $rectorRunRepository, DemoRunner $demoRunner, array $demoLinks)
     {
         $this->rectorRunRepository = $rectorRunRepository;
         $this->demoRunner = $demoRunner;
+        $this->demoLinks = $demoLinks;
     }
 
     /**
@@ -45,19 +54,20 @@ final class DemoController extends AbstractController
     {
         $formData = $this->createDemoFormData($rectorRun);
 
-        $form = $this->createForm(DemoFormType::class, $formData, [
+        $demoForm = $this->createForm(DemoFormType::class, $formData, [
             // this is needed for manual render
             'action' => $this->generateUrl('demo'),
         ]);
-        $form->handleRequest($request);
+        $demoForm->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            return $this->processFormAndReturnRoute($form);
+        if ($demoForm->isSubmitted() && $demoForm->isValid()) {
+            return $this->processFormAndReturnRoute($demoForm);
         }
 
         return $this->render('homepage/demo.twig', [
-            'demo_form' => $form->createView(),
-            'rector_run' => $rectorRun ?? null,
+            'demo_form' => $demoForm->createView(),
+            'rector_run' => $rectorRun,
+            'demo_links' => $this->demoLinks,
         ]);
     }
 

--- a/src/Form/DemoFormType.php
+++ b/src/Form/DemoFormType.php
@@ -39,7 +39,7 @@ final class DemoFormType extends AbstractType
         $formBuilder->add('process', SubmitType::class, [
             'label' => 'Process!',
             'attr' => [
-                'class' => 'btn btn-lg btn-success m-auto',
+                'class' => 'btn btn-lg btn-success m-auto btn-demo-submit',
             ],
         ]);
     }

--- a/src/Lint/PHPLinter.php
+++ b/src/Lint/PHPLinter.php
@@ -4,21 +4,23 @@ declare(strict_types=1);
 
 namespace Rector\Website\Lint;
 
+use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use Rector\Website\Exception\Linter\MissingPHPOpeningTagException;
 use Rector\Website\Exception\LintingException;
 use Symfony\Component\Process\Process;
 
-final class PHPFileLinter
+final class PHPLinter
 {
     public function checkContentSyntax(string $content): void
     {
         $this->checkOpeningPhpTag($content);
 
-        // @see https://stackoverflow.com/a/18243142/1348344
-        // this is needed as pipe is not supported by new Process([])
-        $commandLine = sprintf('echo "%s" | php -l', $content);
-        $process = Process::fromShellCommandline($commandLine);
+        $fileName = md5($content);
+        $filePath = sys_get_temp_dir() . '/temp/' . $fileName;
+        FileSystem::write($filePath, $content);
+
+        $process = new Process(['php', '-l', $filePath]);
         $process->run();
 
         if ($process->isSuccessful()) {

--- a/src/Validator/PHPConstraintValidator.php
+++ b/src/Validator/PHPConstraintValidator.php
@@ -7,7 +7,7 @@ namespace Rector\Website\Validator;
 use Nette\Utils\Strings;
 use Rector\Website\Exception\Linter\MissingPHPOpeningTagException;
 use Rector\Website\Exception\LintingException;
-use Rector\Website\Lint\PHPFileLinter;
+use Rector\Website\Lint\PHPLinter;
 use Rector\Website\Validator\Constraint\PHPConstraint;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -18,13 +18,13 @@ use Symfony\Component\Validator\ConstraintValidator;
 final class PHPConstraintValidator extends ConstraintValidator
 {
     /**
-     * @var PHPFileLinter
+     * @var PHPLinter
      */
-    private $phpFileLinter;
+    private $phpLinter;
 
-    public function __construct(PHPFileLinter $phpFileLinter)
+    public function __construct(PHPLinter $phpLinter)
     {
-        $this->phpFileLinter = $phpFileLinter;
+        $this->phpLinter = $phpLinter;
     }
 
     /**
@@ -34,7 +34,7 @@ final class PHPConstraintValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint): void
     {
         try {
-            $this->phpFileLinter->checkContentSyntax($value);
+            $this->phpLinter->checkContentSyntax($value);
         } catch (MissingPHPOpeningTagException $missingPHPOpeningTagException) {
             $this->context->buildViolation('Add opening "<?php" tag')
                 ->addViolation();

--- a/src/ValueObject/TwigAutocomplete/DemoLink.php
+++ b/src/ValueObject/TwigAutocomplete/DemoLink.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Website\ValueObject\TwigAutocomplete;
+
+/**
+ * Only helper Twig autocomplete class
+ */
+final class DemoLink
+{
+    /**
+     * @var string
+     */
+    public $label;
+
+    /**
+     * @var string
+     */
+    public $uuid;
+}

--- a/templates/_snippets/javascripts.twig
+++ b/templates/_snippets/javascripts.twig
@@ -59,3 +59,11 @@
         });
     });
 </script>
+
+
+<script type="text/javascript">
+    $('.btn-demo-submit').on('click', function (event) {
+        $(this).prepend('<em class="fas fa-sync-alt fa-spin"></em>&nbsp;&nbsp;&nbsp;');
+        $(this).form.submit();
+    });
+</script>

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -10,7 +10,8 @@
     <body id="{% block body_id %}{% endblock %}">
         {% block body %}
             <div id="main">
-                {% if small_headline_design is defined and small_headline_design == true %}
+                {% if no_headline_design is defined %}
+                {% elseif small_headline_design is defined %}
                     <section id="small_header">
                         <div class="container">
                             <div class="row">

--- a/templates/homepage/demo.twig
+++ b/templates/homepage/demo.twig
@@ -1,25 +1,45 @@
 {% extends "base.twig" %}
 
 {% set page_title %}Try Rector Online{% endset %}
-{% set small_headline_design = true %}
+{#{% set small_headline_design = true %}#}
+{% set no_headline_design = true %}
 
 {% block main %}
-    <div class="container-fluid mt-5 pl-5 pr-5 {% if rector_run is not null %}short{% endif %}" id="demo">
+    <div class="container-fluid mt-0 pl-5 pr-5 {% if rector_run is not null %}short{% endif %}" id="demo">
+        <a href="{{ path('homepage') }}" id="main_logo">
+            <img src="{{ asset('assets/images/logo/rector-no_frame_vector.svg') }}" alt="">
+            <div class="logo_text text-dark">Rector</div>
+        </a>
+
+        {% if demo_links|length > 0 %}
+            <p class="mb-4 mt-4">
+                Try these:
+
+                {% for demo_link in demo_links %}
+                    {# @var demo_link \Rector\Website\ValueObject\TwigAutocomplete\DemoLink #}
+                    <a href="{{ path('demo_detail', {'rectorRun': demo_link.uuid}) }}" class="ml-3">{{ demo_link.label }}</a>
+                {% endfor %}
+            </p>
+        {% endif %}
+
+        <div class="clearfix"></div>
+
         {% form_theme demo_form 'bootstrap_4_layout.html.twig' %}
 
         <div id="rector_run_form">
             {{ form_start(demo_form) }}
                 <div class="row">
-                    <div class="col-12 col-md-6">
+                    <div class="col-12">
                         {{ form_row(demo_form.content) }}
                     </div>
-                    <div class="col-12 col-md-6">
+                </div>
+
+                <div class="row">
+                    <div class="col-12">
                         {{ form_row(demo_form.config) }}
 
                         {# @see http://symfony.com/doc/current/security/csrf.html#csrf-protection-in-login-forms #}
                         <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
-
-                        <br>
 
                         {{ form_row(demo_form.process) }}
 

--- a/tests/Validator/Fixture/class.php.inc
+++ b/tests/Validator/Fixture/class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+final class CompleteMe
+{
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcher $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+}

--- a/tests/Validator/PHPConstraintValidatorTest.php
+++ b/tests/Validator/PHPConstraintValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Website\Tests\Validator;
 
 use Iterator;
+use Nette\Utils\FileSystem;
 use Rector\Website\GetRectorKernel;
 use Rector\Website\ValueObject\DemoFormData;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -42,6 +43,9 @@ final class PHPConstraintValidatorTest extends AbstractKernelTestCase
     {
         yield ['<?php echo "hi";'];
         yield [' <?php echo "hi";'];
+
+        $classContent = FileSystem::read(__DIR__ . '/Fixture/class.php.inc');
+        yield [$classContent];
     }
 
     /**


### PR DESCRIPTION
The `rector.yaml` has to be long, so it can include services names, e.g.

![image](https://user-images.githubusercontent.com/924196/72686537-31cb6300-3af6-11ea-9c54-00063de4092f.png)


# Before

![image](https://user-images.githubusercontent.com/924196/72686539-3c85f800-3af6-11ea-8123-c6c0d6d7eb31.png)


# After

![image](https://user-images.githubusercontent.com/924196/72686545-44459c80-3af6-11ea-9bf4-212073b9ec83.png)
