### PR TITLE
Show error when invalid process output instead of „Syntax error“

### DIFF
--- a/src/Process/RectorProcessRunner.php
+++ b/src/Process/RectorProcessRunner.php
@@ -6,6 +6,7 @@ namespace Rector\Website\Process;
 
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
+use Nette\Utils\JsonException;
 use Nette\Utils\Random;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -79,8 +80,12 @@ final class RectorProcessRunner
         $output = $process->getErrorOutput() ?: $process->getOutput();
 
         if ($process->isSuccessful()) {
-            // If it was successful it will output valid json with result
-            return Json::decode($output, Json::FORCE_ARRAY);
+            try {
+                // If it was successful it will output valid json with result
+                return Json::decode($output, Json::FORCE_ARRAY);
+            } catch (JsonException $jsonException) {
+                // Do nothing, RectorRunFailedException will be thrown anyway
+            }
         }
 
         throw new RectorRunFailedException($output);


### PR DESCRIPTION
## Before
<img width="761" alt="Screenshot 2020-01-22 00 57 11" src="https://user-images.githubusercontent.com/3995003/72853679-6552ec80-3cb2-11ea-9a12-a5bb414fb139.png">


## After
<img width="928" alt="Screenshot 2020-01-22 00 55 56" src="https://user-images.githubusercontent.com/3995003/72853687-6ab03700-3cb2-11ea-8f03-4609e1dc9c75.png">
