### PR TITLE
add missing autoload path

### DIFF
--- a/bin/run-demo.sh
+++ b/bin/run-demo.sh
@@ -34,6 +34,7 @@ docker run \
     --volume ${VOLUME_SOURCE}:/project \
     ${DOCKER_IMAGE} \
     process /project/rector_analyzed_file.php \
+    --autoload-file /project/rector_analyzed_file.php \
     --output-format json \
     --config /project/rector.yaml
 


### PR DESCRIPTION
In current version, the analysed file is not included anymore. 
To prevent broken scope of side-effect files.

This fixes the change, see https://github.com/rectorphp/rector#extra-autoloading