### PR TITLE
Show used rector version on demo runs

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -353,8 +353,17 @@ h1 em, h2 em, h2 a {
     min-height: 25em;
     background: #666;
 
-    h2, h3 {
+    h2, h3, .rector-version {
         color: #fcf8e3;
+    }
+
+    .rector-version {
+        font-size: 15px;
+        margin-top: -15px;
+
+        a {
+            font-weight: bold;
+        }
     }
 }
 

--- a/packages/demo/src/Entity/RectorRun.php
+++ b/packages/demo/src/Entity/RectorRun.php
@@ -6,6 +6,7 @@ namespace Rector\Website\Demo\Entity;
 
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
+use Jean85\Version;
 use Nette\Utils\Json;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Stopwatch\StopwatchEvent;
@@ -114,6 +115,21 @@ class RectorRun
     {
         $this->errorMessage = $errorMessage;
         $this->updateTimeElapsed($stopwatchEvent);
+    }
+
+    public function getVersion(): ?Version
+    {
+        if (! $this->resultJson) {
+            return null;
+        }
+
+        $data = Json::decode($this->resultJson, Json::FORCE_ARRAY);
+
+        if (! isset($data['meta']['version'])) {
+            return null;
+        }
+
+        return new Version('rector/rector', $data['meta']['version']);
     }
 
     /**

--- a/templates/demo/demo.twig
+++ b/templates/demo/demo.twig
@@ -55,6 +55,12 @@
 
             <h3 class="mt-0 mb-4 text-left" id="result">Result</h3>
 
+            {% if rector_run.version is not null %}
+                <p class="rector-version">
+                    Used Rector version: <a href="https://github.com/rectorphp/rector/tree/{{ rector_run.version.commitHash }}">{{ rector_run.version.fullVersion }}</a>
+                </p>
+            {% endif %}
+
             {# @var rector_run \Rector\Website\Demo\Entity\RectorRun  #}
             {% if rector_run.successful %}
                 <pre><code class="language-diff">{{ rector_run.contentDiff }}</code></pre>


### PR DESCRIPTION
<img width="812" alt="Screenshot 2020-04-03 23 49 06" src="https://user-images.githubusercontent.com/3995003/78408326-1c4edb00-7607-11ea-8bcd-022b014cbf86.png">
