### PR TITLE
Show fatal error message with newlines

### DIFF
--- a/templates/demo/demo.twig
+++ b/templates/demo/demo.twig
@@ -81,7 +81,7 @@
         {% if rector_run.hasRun and rector_run.successful != true %}
             <div class="alert alert-danger">
                 <strong>Fatal error:</strong>
-                {{ rector_run.fatalErrorMessage }}
+                {{ rector_run.fatalErrorMessage | nl2br }}
             </div>
         {% endif %}
 


### PR DESCRIPTION
## Old
<img width="1043" alt="Screenshot 2021-02-06 at 10 04 53@2x" src="https://user-images.githubusercontent.com/104180/107113979-d97f1480-6862-11eb-99a8-0a2b89bb9c92.png">

## New
<img width="1032" alt="Screenshot 2021-02-06 at 10 05 03@2x" src="https://user-images.githubusercontent.com/104180/107113981-dc7a0500-6862-11eb-9204-e7bc7b67d7a2.png">
