### PR TITLE
Multiple classes diff is wrong

### DIFF
--- a/packages/demo/src/Utils/FileDiffCleaner.php
+++ b/packages/demo/src/Utils/FileDiffCleaner.php
@@ -13,10 +13,16 @@ use Rector\Website\Demo\Entity\RectorRun;
 final class FileDiffCleaner
 {
     /**
-     * @see https://regex101.com/r/sI6GVY/1/
+     * @see https://regex101.com/r/59jq4J/1
      * @var string
      */
-    private const DIFF_START_REGEX = '#^.*?@@\n#Us';
+    private const DIFF_HEADER_ORIGINAL_REGEX = '#--- Original\n#s';
+
+    /**
+     * @see https://regex101.com/r/QMXRXr/1
+     * @var string
+     */
+    private const DIFF_HEADER_NEW_REGEX = '#\+\+\+ New\n#s';
 
     /**
      * @see https://regex101.com/r/wtTr3f/1
@@ -38,7 +44,8 @@ final class FileDiffCleaner
 
     public function clean(string $fileDiff): string
     {
-        $fileDiff = Strings::replace($fileDiff, self::DIFF_START_REGEX, '');
+        $fileDiff = Strings::replace($fileDiff, self::DIFF_HEADER_ORIGINAL_REGEX, '');
+        $fileDiff = Strings::replace($fileDiff, self::DIFF_HEADER_NEW_REGEX, '');
         $fileDiff = Strings::replace($fileDiff, self::NO_NEWLINE_REGEX, '');
 
         $fileDiff = rtrim($fileDiff) . PHP_EOL;

--- a/packages/demo/tests/Utils/Fixture/multiple_classes.txt
+++ b/packages/demo/tests/Utils/Fixture/multiple_classes.txt
@@ -1,0 +1,41 @@
+--- Original
++++ New
+@@ -1,3 +1,3 @@
+ <?php
+ interface FormTypeInterface
+ {
+@@ -9,7 +9,7 @@
+     /**
+      * @var iterable|FormTypeInterface[]
+      */
+-    private $formTypes;
++    private iterable $formTypes;
+
+     /**
+      * @param FormTypeInterface[] $formTypes
+@@ -18,4 +18,4 @@
+     {
+         $this->formTypes = $formTypes;
+     }
+-}
+\ No newline at end of file
++}
+-----
+@@ -1,3 +1,3 @@
+ <?php
+ interface FormTypeInterface
+ {
+@@ -9,7 +9,7 @@
+     /**
+      * @var iterable|FormTypeInterface[]
+      */
+-    private $formTypes;
++    private iterable $formTypes;
+
+     /**
+      * @param FormTypeInterface[] $formTypes
+@@ -18,4 +18,4 @@
+     {
+         $this->formTypes = $formTypes;
+     }
+}

--- a/packages/demo/tests/Utils/Fixture/start_input.txt
+++ b/packages/demo/tests/Utils/Fixture/start_input.txt
@@ -4,5 +4,6 @@
 public function run() { return 5; - - return 10; } }
 -0
 -----
+@@ -5,7 +5,5 @@
 public function run() { return 5; - - return 10; } }
 -0


### PR DESCRIPTION
See #245

I tried to fix this but it's not as easy. The regex always looks for the last part of the diff.

Wouldn't it be better to just show the full diff of the file? Or just show the full content of the changed file? Maybe side by side?