### PR TITLE
Demo > Show failure always on top

### DIFF
--- a/templates/demo/demo.twig
+++ b/templates/demo/demo.twig
@@ -6,6 +6,15 @@
     <div id="rector_run_form" class="mt-4 mb-5">
         {{ form_start(demo_form) }}
 
+        {# @var rector_run \Rector\Website\Demo\Entity\RectorRun #}
+
+        {% if rector_run.hasRun and rector_run.successful != true %}
+            <div class="alert alert-danger">
+                <strong>Fatal error:</strong>
+                {{ rector_run.fatalErrorMessage | nl2br }}
+            </div>
+        {% endif %}
+
         <div class="card mb-5">
             <div class="card-header">Input Code</div>
             <div class="card-body p-0 mb-0">
@@ -75,15 +84,6 @@
         </div>
 
         {{ form_end(demo_form) }}
-
-        {# @var rector_run \Rector\Website\Demo\Entity\RectorRun #}
-
-        {% if rector_run.hasRun and rector_run.successful != true %}
-            <div class="alert alert-danger">
-                <strong>Fatal error:</strong>
-                {{ rector_run.fatalErrorMessage | nl2br }}
-            </div>
-        {% endif %}
 
         <br>
     </div>

--- a/templates/demo/demo.twig
+++ b/templates/demo/demo.twig
@@ -11,7 +11,7 @@
         {% if rector_run.hasRun and rector_run.successful != true %}
             <div class="alert alert-danger">
                 <strong>Fatal error:</strong>
-                {{ rector_run.fatalErrorMessage | nl2br }}
+                {{ rector_run.fatalErrorMessage | trim | nl2br }}
             </div>
         {% endif %}
 


### PR DESCRIPTION
When working on small screens, it's very easy to mis the error messages as they are located under the Process button.

This is also why it took me some time to know that the Demo was broken (#270).

This will improve it.

<img width="1062" alt="Screenshot 2021-02-15 at 11 56 17@2x" src="https://user-images.githubusercontent.com/104180/107937885-da135b80-6f84-11eb-8f0d-4b809cc96ea1.png">
