### PR TITLE
[blog] add rss icon on header

### DIFF
--- a/packages/blog/templates/blog/blog.twig
+++ b/packages/blog/templates/blog/blog.twig
@@ -4,7 +4,14 @@
 
 {% block main %}
     <div id="blog">
-        <h1>Rector Blog</h1>
+        <h1>
+            Rector Blog
+            <span class="float-right">
+                <a href="{{ path('rss') }}" class="p-2">
+                    <em class="fas fa-rss fa-fw fa-xs"></em>
+                </a>
+            </span>
+        </h1>
 
         {% for post in posts %}
             <div class="mb-5">


### PR DESCRIPTION
Adds the RSS icon right next to the header for a better discovery (#247).

![image](https://user-images.githubusercontent.com/171715/108151769-ad388300-7101-11eb-8df2-9902b7aa8d72.png)
