### PR TITLE
[Daily PR] Clean up symplify/* packages include in composer update

### DIFF
--- a/.github/workflows/daily_pull_request_automatic_update.yaml
+++ b/.github/workflows/daily_pull_request_automatic_update.yaml
@@ -17,7 +17,7 @@ jobs:
                 actions:
                     -
                         name: "Update Rector Dependencies"
-                        run: "composer update rector/rector  symplify/amnesia symplify/autowire-array-parameter symplify/composer-json-manipulator symplify/easy-testing symplify/markdown-diff symplify/package-builder symplify/php-config-printer symplify/rule-doc-generator symplify/simple-php-doc-parser symplify/skipper symplify/smart-file-system symplify/symfony-php-config symplify/symplify-kernel symplify/coding-standard symplify/easy-coding-standard symplify/phpstan-extensions symplify/phpstan-rules --with-all-dependencies"
+                        run: "composer update rector/rector --with-all-dependencies"
                         branch: 'automated-regenerated-composer-lock'
 
         name: ${{ matrix.actions.name }}


### PR DESCRIPTION
The simplify/* packages are pinned with version 9.4.22

https://github.com/rectorphp/getrector.org/blob/28fe90b6c1aae941fddfe3458d10c9586980b36e/composer.json#L46-L58

and already synced with composer.lock