### PR TITLE
Update 2021-10-18-how-all-frameworks-can-bump-to-php-81-and-you-can-u…

### DIFF
--- a/data/blog/posts/2021/2021-10-18-how-all-frameworks-can-bump-to-php-81-and-you-can-use-older-php.md
+++ b/data/blog/posts/2021/2021-10-18-how-all-frameworks-can-bump-to-php-81-and-you-can-use-older-php.md
@@ -165,7 +165,7 @@ use Rector\Set\ValueObject\DowngradeLevelSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_71);
+    $containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_80);
 };
 ```
 


### PR DESCRIPTION
…se-older-php.md

changed php version in the `rector-downgrade.php` to keep it with description provided above