### PR TITLE
Update to use latest PHPStan ^1.5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^1.5",
+        "phpstan/phpstan": "^1.5.6",
         "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-master",
         "symplify/coding-standard": "^10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca7b60a04b8bf502b5905d8a25cc9089",
+    "content-hash": "3bd7f682c3550ac79b255ff1c4019bff",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -354,16 +354,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.5.5",
+            "version": "1.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d77a607667f29ae099c0686f99664bd451fd23df"
+                "reference": "799dd8c2d2c9c704bb55d2078078cb970cf0f6d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d77a607667f29ae099c0686f99664bd451fd23df",
-                "reference": "d77a607667f29ae099c0686f99664bd451fd23df",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/799dd8c2d2c9c704bb55d2078078cb970cf0f6d1",
+                "reference": "799dd8c2d2c9c704bb55d2078078cb970cf0f6d1",
                 "shasum": ""
             },
             "require": {
@@ -389,7 +389,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.5.5"
+                "source": "https://github.com/phpstan/phpstan/tree/1.5.6"
             },
             "funding": [
                 {
@@ -409,7 +409,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-14T12:20:26+00:00"
+            "time": "2022-04-15T11:13:37+00:00"
         },
         {
             "name": "psr/cache",
@@ -619,17 +619,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "254106fbd69e35e2b827cf6db968451d5d4c99fc"
+                "reference": "b733212c384ece037e5209ee10aae580855c1e7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/254106fbd69e35e2b827cf6db968451d5d4c99fc",
-                "reference": "254106fbd69e35e2b827cf6db968451d5d4c99fc",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b733212c384ece037e5209ee10aae580855c1e7d",
+                "reference": "b733212c384ece037e5209ee10aae580855c1e7d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.5.5"
+                "phpstan/phpstan": "^1.5.6"
             },
             "conflict": {
                 "phpstan/phpdoc-parser": "<1.2",
@@ -672,7 +672,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-14T21:57:42+00:00"
+            "time": "2022-04-15T17:36:53+00:00"
         },
         {
             "name": "sebastian/diff",


### PR DESCRIPTION
as composer.json using `rector/rector` `dev-main`, PHPStan need to use PHPStan ^1.5.6 in composer.lock and composer.json due to https://github.com/rectorphp/rector-src/pull/2014