### PR TITLE
Fix First Run link linked when open from non homepage

### DIFF
--- a/templates/_snippets/menu.twig
+++ b/templates/_snippets/menu.twig
@@ -10,7 +10,7 @@
                 </li>
 
                 <li class="nav-item">
-                    <a href="#first-run" class="nav-link">First Run</a>
+                    <a href="/#first-run" class="nav-link">First Run</a>
                 </li>
 
 


### PR DESCRIPTION
When user open different page, eg: `/blog`, then click `First Run` link, it currently only append `#first-run` instead of go to home page with `#first-run` id: `https://getrector.org/blog#first-run`. 

This PR fix it.