### PR TITLE
Add phpstan-phpdoc-parser to daily update

### DIFF
--- a/.github/workflows/daily_pull_request_automatic_update.yaml
+++ b/.github/workflows/daily_pull_request_automatic_update.yaml
@@ -17,7 +17,7 @@ jobs:
                 actions:
                     -
                         name: "Update Rector Dependencies"
-                        run: "composer update rector/rector --with-all-dependencies"
+                        run: "composer update rector/rector phpstan/phpdoc-parser --with-all-dependencies"
                         branch: 'automated-regenerated-composer-lock'
 
         name: ${{ matrix.actions.name }}

--- a/composer.lock
+++ b/composer.lock
@@ -551,12 +551,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "fd299c83a6c8a8b8d96903485907b5dc0c9bda50"
+                "reference": "418223409c4d94b09deb38e75f4dcd660122dafb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/fd299c83a6c8a8b8d96903485907b5dc0c9bda50",
-                "reference": "fd299c83a6c8a8b8d96903485907b5dc0c9bda50",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/418223409c4d94b09deb38e75f4dcd660122dafb",
+                "reference": "418223409c4d94b09deb38e75f4dcd660122dafb",
                 "shasum": ""
             },
             "require": {
@@ -564,7 +564,7 @@
                 "phpstan/phpstan": "^1.7.12"
             },
             "conflict": {
-                "phpstan/phpdoc-parser": "<1.2",
+                "phpstan/phpdoc-parser": "<1.6.2",
                 "rector/rector-cakephp": "*",
                 "rector/rector-doctrine": "*",
                 "rector/rector-laravel": "*",
@@ -604,7 +604,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T13:32:28+00:00"
+            "time": "2022-06-10T10:17:45+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -5885,16 +5885,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.6.0",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "3cb62d10845338136ff4ba299ab0986bbf84ba77"
+                "reference": "76150ae7512439b4e6903db834e4a327596b617d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/3cb62d10845338136ff4ba299ab0986bbf84ba77",
-                "reference": "3cb62d10845338136ff4ba299ab0986bbf84ba77",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/76150ae7512439b4e6903db834e4a327596b617d",
+                "reference": "76150ae7512439b4e6903db834e4a327596b617d",
                 "shasum": ""
             },
             "require": {
@@ -5904,6 +5904,7 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
@@ -5923,9 +5924,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.2"
             },
-            "time": "2022-06-09T09:45:59+00:00"
+            "time": "2022-06-10T09:29:33+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
The current command will get the following output:

```bash
composer update rector/rector --with-all-dependencies
Gathering patches for root package.
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires rector/rector dev-main -> satisfiable by rector/rector[dev-main].
    - symplify/phpstan-rules 10.3.0 requires phpstan/phpdoc-parser ^1.6.0 -> satisfiable by phpstan/phpdoc-parser[1.6.0].
    - rector/rector dev-main conflicts with phpstan/phpdoc-parser <1.6.2.
    - symplify/phpstan-rules is locked to version 10.3.0 and an update of this package was not requested.
```

updated to : 

```
composer update rector/rector phpstan/phpdoc-parser --with-all-dependencies


Gathering patches for root package.
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading phpstan/phpdoc-parser (1.6.0 => 1.6.2)
  - Upgrading rector/rector (dev-main fd299c8 => dev-main 4182234)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Upgrading rector/rector (dev-main fd299c8 => dev-main 4182234): Extracting archive
  - Upgrading phpstan/phpdoc-parser (1.6.0 => 1.6.2): Extracting archive
Package symplify/amnesia is abandoned, you should avoid using it. Use https://symfony.com/blog/new-in-symfony-5-3-config-builder-classes instead.
Generating autoload files
91 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
phpstan/extension-installer: Extensions installed
```

will make it works