### PR TITLE
Fix daily PR: use symplify/amnesia:10.2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/web-profiler-bundle": "^6.1",
         "symfony/webpack-encore-bundle": "^1.13",
         "symfony/yaml": "^6.1",
-        "symplify/amnesia": "^10.2.7",
+        "symplify/amnesia": "10.2.7 as 11.0",
         "symplify/autowire-array-parameter": "^11.0",
         "symplify/package-builder": "^11.0",
         "symplify/smart-file-system": "^11.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/web-profiler-bundle": "^6.1",
         "symfony/webpack-encore-bundle": "^1.13",
         "symfony/yaml": "^6.1",
-        "symplify/amnesia": "^11.0",
+        "symplify/amnesia": "^10.2.7",
         "symplify/autowire-array-parameter": "^11.0",
         "symplify/package-builder": "^11.0",
         "symplify/smart-file-system": "^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cc01ac6b8b9c0c165bdc8122638dd7b",
+    "content-hash": "cc51d28bfc24783a24cfd8fddd290dd7",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -551,12 +551,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "b050f5de99d7db52636f2a894af6ee1d4b1d49d3"
+                "reference": "ff718bc1072aaffa1657b175fdd92e6cbe0222df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b050f5de99d7db52636f2a894af6ee1d4b1d49d3",
-                "reference": "b050f5de99d7db52636f2a894af6ee1d4b1d49d3",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ff718bc1072aaffa1657b175fdd92e6cbe0222df",
+                "reference": "ff718bc1072aaffa1657b175fdd92e6cbe0222df",
                 "shasum": ""
             },
             "require": {
@@ -604,7 +604,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-07-03T23:03:40+00:00"
+            "time": "2022-07-05T07:33:24+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -746,16 +746,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "364fc90734230d936ac2db8e897cc03ec8497bbb"
+                "reference": "7d8415956df68c8dcbc9468e119945e39bacead1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/364fc90734230d936ac2db8e897cc03ec8497bbb",
-                "reference": "364fc90734230d936ac2db8e897cc03ec8497bbb",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/7d8415956df68c8dcbc9468e119945e39bacead1",
+                "reference": "7d8415956df68c8dcbc9468e119945e39bacead1",
                 "shasum": ""
             },
             "require": {
@@ -822,7 +822,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.1.1"
+                "source": "https://github.com/symfony/cache/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -838,11 +838,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-06T19:15:01+00:00"
+            "time": "2022-06-19T13:21:48+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
@@ -901,7 +901,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -998,16 +998,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6187424023fbffcd757789aeb517c9161b1eabee"
+                "reference": "7a86c1c42fbcb69b59768504c7bca1d3767760b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6187424023fbffcd757789aeb517c9161b1eabee",
-                "reference": "6187424023fbffcd757789aeb517c9161b1eabee",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7a86c1c42fbcb69b59768504c7bca1d3767760b7",
+                "reference": "7a86c1c42fbcb69b59768504c7bca1d3767760b7",
                 "shasum": ""
             },
             "require": {
@@ -1074,7 +1074,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.1.1"
+                "source": "https://github.com/symfony/console/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -1090,7 +1090,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-08T14:02:09+00:00"
+            "time": "2022-06-26T13:01:30+00:00"
         },
         {
             "name": "symfony/debug-bundle",
@@ -1172,16 +1172,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.1.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "fc1fcd2b153f585934e80055bb3254913def2a6e"
+                "reference": "5635ff016a814d7984b1c4644ad28e7df546077b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/fc1fcd2b153f585934e80055bb3254913def2a6e",
-                "reference": "fc1fcd2b153f585934e80055bb3254913def2a6e",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5635ff016a814d7984b1c4644ad28e7df546077b",
+                "reference": "5635ff016a814d7984b1c4644ad28e7df546077b",
                 "shasum": ""
             },
             "require": {
@@ -1239,7 +1239,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.1.0"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -1255,11 +1255,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-27T06:40:20+00:00"
+            "time": "2022-06-26T13:01:30+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -1306,7 +1306,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -1553,7 +1553,7 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
@@ -1612,7 +1612,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -1759,16 +1759,16 @@
         },
         {
             "name": "symfony/form",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "630eed7b1282f18a8399a0a2b3fb71c44266b73a"
+                "reference": "e7d5c8967096267d1b55e4278733aaf2bbe92528"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/630eed7b1282f18a8399a0a2b3fb71c44266b73a",
-                "reference": "630eed7b1282f18a8399a0a2b3fb71c44266b73a",
+                "url": "https://api.github.com/repos/symfony/form/zipball/e7d5c8967096267d1b55e4278733aaf2bbe92528",
+                "reference": "e7d5c8967096267d1b55e4278733aaf2bbe92528",
                 "shasum": ""
             },
             "require": {
@@ -1841,7 +1841,7 @@
             "description": "Allows to easily create, process and reuse HTML forms",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/form/tree/v6.1.1"
+                "source": "https://github.com/symfony/form/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -1857,20 +1857,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T12:51:38+00:00"
+            "time": "2022-06-19T13:21:48+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "260d97823252318eb3b525dd8c0bee2cc5dbfd7f"
+                "reference": "2a5c75abda7887b030fdcc7ce441d9b4a5bf1744"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/260d97823252318eb3b525dd8c0bee2cc5dbfd7f",
-                "reference": "260d97823252318eb3b525dd8c0bee2cc5dbfd7f",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/2a5c75abda7887b030fdcc7ce441d9b4a5bf1744",
+                "reference": "2a5c75abda7887b030fdcc7ce441d9b4a5bf1744",
                 "shasum": ""
             },
             "require": {
@@ -1992,7 +1992,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v6.1.1"
+                "source": "https://github.com/symfony/framework-bundle/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -2008,20 +2008,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T10:53:06+00:00"
+            "time": "2022-06-26T10:01:04+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "a58dc88d56e04e57993d96c1407a17407610e1df"
+                "reference": "86119d294e51afe4d8e07da96b63332bd1f3f52c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a58dc88d56e04e57993d96c1407a17407610e1df",
-                "reference": "a58dc88d56e04e57993d96c1407a17407610e1df",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/86119d294e51afe4d8e07da96b63332bd1f3f52c",
+                "reference": "86119d294e51afe4d8e07da96b63332bd1f3f52c",
                 "shasum": ""
             },
             "require": {
@@ -2064,7 +2064,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.1.1"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -2080,20 +2080,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-31T14:28:03+00:00"
+            "time": "2022-06-19T13:21:48+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "86c4d6f6c5b6cd012df41e3b950c924b3ffdc019"
+                "reference": "8aaede489900dda61aee208557f63bfa1bca0877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/86c4d6f6c5b6cd012df41e3b950c924b3ffdc019",
-                "reference": "86c4d6f6c5b6cd012df41e3b950c924b3ffdc019",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8aaede489900dda61aee208557f63bfa1bca0877",
+                "reference": "8aaede489900dda61aee208557f63bfa1bca0877",
                 "shasum": ""
             },
             "require": {
@@ -2174,7 +2174,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.1.1"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -2190,7 +2190,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T17:31:33+00:00"
+            "time": "2022-06-26T17:06:14+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -2900,16 +2900,16 @@
         },
         {
             "name": "symfony/property-info",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "3d328abe4aac447360cafa6ba6f019db0c12f378"
+                "reference": "4989684b39c929fcf3ba432afdd932879fbc1334"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/3d328abe4aac447360cafa6ba6f019db0c12f378",
-                "reference": "3d328abe4aac447360cafa6ba6f019db0c12f378",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/4989684b39c929fcf3ba432afdd932879fbc1334",
+                "reference": "4989684b39c929fcf3ba432afdd932879fbc1334",
                 "shasum": ""
             },
             "require": {
@@ -2969,7 +2969,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v6.1.1"
+                "source": "https://github.com/symfony/property-info/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -2985,7 +2985,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-31T17:22:23+00:00"
+            "time": "2022-06-10T06:48:13+00:00"
         },
         {
             "name": "symfony/routing",
@@ -3077,16 +3077,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d66cd8ab656780f62c4215b903a420eb86358957"
+                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d66cd8ab656780f62c4215b903a420eb86358957",
-                "reference": "d66cd8ab656780f62c4215b903a420eb86358957",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/925e713fe8fcacf6bc05e936edd8dd5441a21239",
+                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239",
                 "shasum": ""
             },
             "require": {
@@ -3142,7 +3142,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -3158,20 +3158,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-07T08:07:09+00:00"
+            "time": "2022-05-30T19:18:58+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.1.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d3edc75baf9f1d4f94879764dda2e1ac33499529"
+                "reference": "1903f2879875280c5af944625e8246d81c2f0604"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d3edc75baf9f1d4f94879764dda2e1ac33499529",
-                "reference": "d3edc75baf9f1d4f94879764dda2e1ac33499529",
+                "url": "https://api.github.com/repos/symfony/string/zipball/1903f2879875280c5af944625e8246d81c2f0604",
+                "reference": "1903f2879875280c5af944625e8246d81c2f0604",
                 "shasum": ""
             },
             "require": {
@@ -3227,7 +3227,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.1.0"
+                "source": "https://github.com/symfony/string/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -3243,7 +3243,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-22T08:18:23+00:00"
+            "time": "2022-06-26T16:35:04+00:00"
         },
         {
             "name": "symfony/templating",
@@ -3315,16 +3315,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "bfddd2a1faa271b782b791c361cc16e2dd49dfaa"
+                "reference": "606be0f48e05116baef052f7f3abdb345c8e02cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/bfddd2a1faa271b782b791c361cc16e2dd49dfaa",
-                "reference": "bfddd2a1faa271b782b791c361cc16e2dd49dfaa",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/606be0f48e05116baef052f7f3abdb345c8e02cc",
+                "reference": "606be0f48e05116baef052f7f3abdb345c8e02cc",
                 "shasum": ""
             },
             "require": {
@@ -3376,7 +3376,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -3392,20 +3392,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-22T07:30:54+00:00"
+            "time": "2022-06-27T17:24:16+00:00"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v6.1.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "53ce2d7811500c0f0f94af700307ff5b1e305d3c"
+                "reference": "320b9ec7db38b78ce2ea8173b925be55e697f8e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/53ce2d7811500c0f0f94af700307ff5b1e305d3c",
-                "reference": "53ce2d7811500c0f0f94af700307ff5b1e305d3c",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/320b9ec7db38b78ce2ea8173b925be55e697f8e5",
+                "reference": "320b9ec7db38b78ce2ea8173b925be55e697f8e5",
                 "shasum": ""
             },
             "require": {
@@ -3498,7 +3498,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v6.1.0"
+                "source": "https://github.com/symfony/twig-bridge/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -3514,7 +3514,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-21T13:34:40+00:00"
+            "time": "2022-06-19T13:21:48+00:00"
         },
         {
             "name": "symfony/twig-bundle",
@@ -3838,23 +3838,23 @@
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "2a5bdd2d82dda75475c428c0fd1d59b6d7aad117"
+                "reference": "6589c2ee4b94d7df2f8ca160ec41265fee3f33eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/2a5bdd2d82dda75475c428c0fd1d59b6d7aad117",
-                "reference": "2a5bdd2d82dda75475c428c0fd1d59b6d7aad117",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/6589c2ee4b94d7df2f8ca160ec41265fee3f33eb",
+                "reference": "6589c2ee4b94d7df2f8ca160ec41265fee3f33eb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/config": "^5.4|^6.0",
                 "symfony/framework-bundle": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/http-kernel": "^6.1",
                 "symfony/routing": "^5.4|^6.0",
                 "symfony/twig-bundle": "^5.4|^6.0",
                 "twig/twig": "^2.13|^3.0.4"
@@ -3896,7 +3896,7 @@
             "description": "Provides a development tool that gives detailed information about the execution of any request",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/web-profiler-bundle/tree/v6.1.1"
+                "source": "https://github.com/symfony/web-profiler-bundle/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -3912,7 +3912,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-06T19:15:01+00:00"
+            "time": "2022-06-12T09:53:37+00:00"
         },
         {
             "name": "symfony/webpack-encore-bundle",
@@ -3987,16 +3987,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.1.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "84ce4f9d2d68f306f971a39d949d8f4b5550dba2"
+                "reference": "b01c4e7dc6a51cbf114567af04a19789fd1011fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/84ce4f9d2d68f306f971a39d949d8f4b5550dba2",
-                "reference": "84ce4f9d2d68f306f971a39d949d8f4b5550dba2",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b01c4e7dc6a51cbf114567af04a19789fd1011fe",
+                "reference": "b01c4e7dc6a51cbf114567af04a19789fd1011fe",
                 "shasum": ""
             },
             "require": {
@@ -4041,7 +4041,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.1.0"
+                "source": "https://github.com/symfony/yaml/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -4057,7 +4057,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-15T14:25:02+00:00"
+            "time": "2022-06-20T12:01:07+00:00"
         },
         {
             "name": "symplify/amnesia",
@@ -4141,45 +4141,45 @@
         },
         {
             "name": "symplify/autowire-array-parameter",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/autowire-array-parameter.git",
-                "reference": "d38fbab11ea98ba55d28664652bbf00c5b74a9f1"
+                "reference": "def69d2cd84901d7169d374d267bb5c564034f33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/d38fbab11ea98ba55d28664652bbf00c5b74a9f1",
-                "reference": "d38fbab11ea98ba55d28664652bbf00c5b74a9f1",
+                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/def69d2cd84901d7169d374d267bb5c564034f33",
+                "reference": "def69d2cd84901d7169d374d267bb5c564034f33",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
                 "symfony/dependency-injection": "^6.0",
-                "symplify/package-builder": "^10.3"
+                "symplify/package-builder": "^11.0.7"
             },
             "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/composer-json-manipulator": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/smart-file-system": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/symplify-kernel": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/astral": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/composer-json-manipulator": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/rule-doc-generator-contracts": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/smart-file-system": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/symplify-kernel": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -4187,7 +4187,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -4201,7 +4201,7 @@
             ],
             "description": "Autowire array parameters for your Symfony applications",
             "support": {
-                "source": "https://github.com/symplify/autowire-array-parameter/tree/10.3.0"
+                "source": "https://github.com/symplify/autowire-array-parameter/tree/11.0.7"
             },
             "funding": [
                 {
@@ -4213,20 +4213,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:14:04+00:00"
+            "time": "2022-07-04T21:51:48+00:00"
         },
         {
             "name": "symplify/composer-json-manipulator",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/composer-json-manipulator.git",
-                "reference": "783c83aae9779a0370587feb03d2c0e2050ba761"
+                "reference": "128872e659592cd5037fdfad46875b420b5bfbf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/783c83aae9779a0370587feb03d2c0e2050ba761",
-                "reference": "783c83aae9779a0370587feb03d2c0e2050ba761",
+                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/128872e659592cd5037fdfad46875b420b5bfbf2",
+                "reference": "128872e659592cd5037fdfad46875b420b5bfbf2",
                 "shasum": ""
             },
             "require": {
@@ -4235,30 +4235,30 @@
                 "symfony/config": "^6.0",
                 "symfony/dependency-injection": "^6.0",
                 "symfony/filesystem": "^6.0",
-                "symplify/package-builder": "^10.3",
-                "symplify/smart-file-system": "^10.3",
-                "symplify/symplify-kernel": "^10.3"
+                "symplify/package-builder": "^11.0.7",
+                "symplify/smart-file-system": "^11.0.7",
+                "symplify/symplify-kernel": "^11.0.7"
             },
             "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
+                "symplify/astral": "<11.0.7",
+                "symplify/autowire-array-parameter": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/rule-doc-generator-contracts": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
                 "symplify/symplify-kernel": "<9.4.70",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -4266,7 +4266,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -4280,7 +4280,7 @@
             ],
             "description": "Package to load, merge and save composer.json file(s)",
             "support": {
-                "source": "https://github.com/symplify/composer-json-manipulator/tree/10.3.0"
+                "source": "https://github.com/symplify/composer-json-manipulator/tree/11.0.7"
             },
             "funding": [
                 {
@@ -4292,20 +4292,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:14:24+00:00"
+            "time": "2022-07-04T21:51:35+00:00"
         },
         {
             "name": "symplify/easy-testing",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-testing.git",
-                "reference": "4101cb6829dabe22aaf138b2a6de82984632e46e"
+                "reference": "3e5a425df54836ff45ac343fd0ceb065fec8a5dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/4101cb6829dabe22aaf138b2a6de82984632e46e",
-                "reference": "4101cb6829dabe22aaf138b2a6de82984632e46e",
+                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/3e5a425df54836ff45ac343fd0ceb065fec8a5dd",
+                "reference": "3e5a425df54836ff45ac343fd0ceb065fec8a5dd",
                 "shasum": ""
             },
             "require": {
@@ -4314,29 +4314,29 @@
                 "symfony/console": "^6.0",
                 "symfony/dependency-injection": "^6.0",
                 "symfony/finder": "^6.0",
-                "symplify/package-builder": "^10.3",
-                "symplify/smart-file-system": "^10.3",
-                "symplify/symplify-kernel": "^10.3"
+                "symplify/package-builder": "^11.0.7",
+                "symplify/smart-file-system": "^11.0.7",
+                "symplify/symplify-kernel": "^11.0.7"
             },
             "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/composer-json-manipulator": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/astral": "<11.0.7",
+                "symplify/autowire-array-parameter": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/composer-json-manipulator": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/rule-doc-generator-contracts": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -4347,7 +4347,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -4361,7 +4361,7 @@
             ],
             "description": "Testing made easy",
             "support": {
-                "source": "https://github.com/symplify/easy-testing/tree/10.3.0"
+                "source": "https://github.com/symplify/easy-testing/tree/11.0.7"
             },
             "funding": [
                 {
@@ -4373,20 +4373,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:14:22+00:00"
+            "time": "2022-07-04T21:52:09+00:00"
         },
         {
             "name": "symplify/package-builder",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/package-builder.git",
-                "reference": "e9cff48316cb79dbd66961d56de14d4db34fb77b"
+                "reference": "affac8c48609e3809d8f59f53d443e63ad903604"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/package-builder/zipball/e9cff48316cb79dbd66961d56de14d4db34fb77b",
-                "reference": "e9cff48316cb79dbd66961d56de14d4db34fb77b",
+                "url": "https://api.github.com/repos/symplify/package-builder/zipball/affac8c48609e3809d8f59f53d443e63ad903604",
+                "reference": "affac8c48609e3809d8f59f53d443e63ad903604",
                 "shasum": ""
             },
             "require": {
@@ -4397,29 +4397,29 @@
                 "symfony/console": "^6.0",
                 "symfony/dependency-injection": "^6.0",
                 "symfony/finder": "^6.0",
-                "symplify/easy-testing": "^10.3",
-                "symplify/symplify-kernel": "^10.3"
+                "symplify/easy-testing": "^11.0.7",
+                "symplify/symplify-kernel": "^11.0.7"
             },
             "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/composer-json-manipulator": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/smart-file-system": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/astral": "<11.0.7",
+                "symplify/autowire-array-parameter": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/composer-json-manipulator": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/rule-doc-generator-contracts": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/smart-file-system": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -4427,7 +4427,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -4441,7 +4441,7 @@
             ],
             "description": "Dependency Injection, Console and Kernel toolkit for Symplify packages.",
             "support": {
-                "source": "https://github.com/symplify/package-builder/tree/10.3.0"
+                "source": "https://github.com/symplify/package-builder/tree/11.0.7"
             },
             "funding": [
                 {
@@ -4453,20 +4453,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:14:38+00:00"
+            "time": "2022-07-04T21:52:22+00:00"
         },
         {
             "name": "symplify/smart-file-system",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/smart-file-system.git",
-                "reference": "ddf15722096e9b36ad7345398dde156be0530daa"
+                "reference": "a8ede3290791f636023c820247237a79182d6376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/ddf15722096e9b36ad7345398dde156be0530daa",
-                "reference": "ddf15722096e9b36ad7345398dde156be0530daa",
+                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/a8ede3290791f636023c820247237a79182d6376",
+                "reference": "a8ede3290791f636023c820247237a79182d6376",
                 "shasum": ""
             },
             "require": {
@@ -4476,27 +4476,27 @@
                 "symfony/finder": "^6.0"
             },
             "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/composer-json-manipulator": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/package-builder": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/symplify-kernel": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/astral": "<11.0.7",
+                "symplify/autowire-array-parameter": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/composer-json-manipulator": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/package-builder": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/rule-doc-generator-contracts": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/symplify-kernel": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "nette/finder": "^2.5",
@@ -4505,7 +4505,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -4519,7 +4519,7 @@
             ],
             "description": "Sanitized FileInfo with safe getRealPath() and other handy methods",
             "support": {
-                "source": "https://github.com/symplify/smart-file-system/tree/10.3.0"
+                "source": "https://github.com/symplify/smart-file-system/tree/11.0.7"
             },
             "funding": [
                 {
@@ -4531,50 +4531,50 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:15:18+00:00"
+            "time": "2022-07-04T21:53:03+00:00"
         },
         {
             "name": "symplify/symplify-kernel",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/symplify-kernel.git",
-                "reference": "b04066c180513d0a87e0643ef58451506f910995"
+                "reference": "7b88d0e5465fbe8e3d7ef865d1a5c42e68dd9be0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/b04066c180513d0a87e0643ef58451506f910995",
-                "reference": "b04066c180513d0a87e0643ef58451506f910995",
+                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/7b88d0e5465fbe8e3d7ef865d1a5c42e68dd9be0",
+                "reference": "7b88d0e5465fbe8e3d7ef865d1a5c42e68dd9be0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "symfony/console": "^6.0",
                 "symfony/dependency-injection": "^6.0",
-                "symplify/autowire-array-parameter": "^10.3",
-                "symplify/composer-json-manipulator": "^10.3",
-                "symplify/package-builder": "^10.3",
-                "symplify/smart-file-system": "^10.3",
+                "symplify/autowire-array-parameter": "^11.0.7",
+                "symplify/composer-json-manipulator": "^11.0.7",
+                "symplify/package-builder": "^11.0.7",
+                "symplify/smart-file-system": "^11.0.7",
                 "webmozart/assert": "^1.10"
             },
             "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/astral": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/rule-doc-generator-contracts": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -4582,7 +4582,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -4596,57 +4596,27 @@
             ],
             "description": "Internal Kernel for Symplify packages",
             "support": {
-                "source": "https://github.com/symplify/symplify-kernel/tree/10.3.0"
+                "source": "https://github.com/symplify/symplify-kernel/tree/11.0.7"
             },
-            "time": "2022-06-09T23:15:39+00:00"
+            "time": "2022-07-04T21:53:10+00:00"
         },
         {
             "name": "symplify/vendor-patches",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/vendor-patches.git",
-                "reference": "8bbe5e2eb3ff6c791cee5b7e7502c2aae1b5394f"
+                "reference": "5cc4516de4a3613cb6daa4329a6f342103832a51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/vendor-patches/zipball/8bbe5e2eb3ff6c791cee5b7e7502c2aae1b5394f",
-                "reference": "8bbe5e2eb3ff6c791cee5b7e7502c2aae1b5394f",
+                "url": "https://api.github.com/repos/symplify/vendor-patches/zipball/5cc4516de4a3613cb6daa4329a6f342103832a51",
+                "reference": "5cc4516de4a3613cb6daa4329a6f342103832a51",
                 "shasum": ""
             },
             "require": {
                 "cweagans/composer-patches": "^1.7",
-                "nette/utils": "^3.2",
-                "php": ">=8.0",
-                "sebastian/diff": "^4.0",
-                "symfony/console": "^6.0",
-                "symfony/dependency-injection": "^6.0",
-                "symplify/composer-json-manipulator": "^10.3",
-                "symplify/symplify-kernel": "^10.3"
-            },
-            "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/package-builder": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/smart-file-system": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "php": ">=7.2"
             },
             "bin": [
                 "bin/vendor-patches"
@@ -4657,20 +4627,25 @@
                     "dev-main": "10.3-dev"
                 }
             },
-            "autoload": {
-                "psr-4": {
-                    "Symplify\\VendorPatches\\": "src"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Generate vendor patches for packages with single command",
             "support": {
-                "source": "https://github.com/symplify/vendor-patches/tree/10.3.0"
+                "source": "https://github.com/symplify/vendor-patches/tree/11.0.7"
             },
-            "time": "2022-06-09T23:15:30+00:00"
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rectorphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-07-04T21:51:58+00:00"
         },
         {
             "name": "twig/twig",
@@ -5028,16 +5003,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.13.2",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08"
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5b668aef16090008790395c02c893b1ba13f7e08",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
                 "shasum": ""
             },
             "require": {
@@ -5049,9 +5024,10 @@
             "require-dev": {
                 "doctrine/cache": "^1.11 || ^2.0",
                 "doctrine/coding-standard": "^6.0 || ^8.1",
-                "phpstan/phpstan": "^0.12.20",
+                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
                 "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-                "symfony/cache": "^4.4 || ^5.2"
+                "symfony/cache": "^4.4 || ^5.2",
+                "vimeo/psalm": "^4.10"
             },
             "type": "library",
             "autoload": {
@@ -5094,9 +5070,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.13.2"
+                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
             },
-            "time": "2021-08-05T19:00:23+00:00"
+            "time": "2022-07-02T10:48:51+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -6248,16 +6224,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -6291,7 +6267,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -6335,7 +6310,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -6347,7 +6322,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -6355,12 +6330,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "eb3f283cd897fee03bd8c3557e03b5928fcbda34"
+                "reference": "7a8c86df136ffe6bd7bc4655d15629a87e5bd022"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/eb3f283cd897fee03bd8c3557e03b5928fcbda34",
-                "reference": "eb3f283cd897fee03bd8c3557e03b5928fcbda34",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/7a8c86df136ffe6bd7bc4655d15629a87e5bd022",
+                "reference": "7a8c86df136ffe6bd7bc4655d15629a87e5bd022",
                 "shasum": ""
             },
             "conflict": {
@@ -6394,6 +6369,8 @@
                 "bottelet/flarepoint": "<2.2.1",
                 "brightlocal/phpwhois": "<=4.2.5",
                 "brotkrueml/codehighlight": "<2.7",
+                "brotkrueml/schema": "<1.13.1|>=2,<2.5.1",
+                "brotkrueml/typo3-matomo-integration": "<1.3.2",
                 "buddypress/buddypress": "<7.2.1",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
                 "bytefury/crater": "<6.0.2",
@@ -6411,7 +6388,7 @@
                 "codiad/codiad": "<=2.8.4",
                 "composer/composer": "<1.10.26|>=2-alpha.1,<2.2.12|>=2.3,<2.3.5",
                 "concrete5/concrete5": "<9",
-                "concrete5/core": "<8.5.7",
+                "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3",
                 "contao/core": ">=2,<3.5.39",
@@ -6436,13 +6413,14 @@
                 "doctrine/mongodb-odm": ">=1,<1.0.2",
                 "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
-                "dolibarr/dolibarr": "<16|>= 3.3.beta1, < 13.0.2",
+                "dolibarr/dolibarr": "<16|= 12.0.5|>= 3.3.beta1, < 13.0.2",
                 "dompdf/dompdf": "<1.2.1",
                 "drupal/core": ">=7,<7.88|>=8,<9.2.13|>=9.3,<9.3.6",
                 "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
                 "dweeves/magmi": "<=0.7.24",
                 "ecodev/newsletter": "<=4",
                 "ectouch/ectouch": "<=2.7.2",
+                "elefant/cms": "<1.3.13",
                 "elgg/elgg": "<3.3.24|>=4,<4.0.5",
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enshrined/svg-sanitize": "<0.15",
@@ -6479,7 +6457,7 @@
                 "fooman/tcpdf": "<6.2.22",
                 "forkcms/forkcms": "<5.11.1",
                 "fossar/tcpdf-parser": "<6.2.22",
-                "francoisjacquet/rosariosis": "<8.1.1",
+                "francoisjacquet/rosariosis": "<9.1",
                 "friendsofsymfony/oauth2-php": "<1.3",
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
@@ -6499,7 +6477,7 @@
                 "gree/jose": "<=2.2",
                 "gregwar/rst": "<1.0.3",
                 "grumpydictator/firefly-iii": "<5.6.5",
-                "guzzlehttp/guzzle": "<6.5.6|>=7,<7.4.3",
+                "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
                 "guzzlehttp/psr7": "<1.8.4|>=2,<2.1.1",
                 "helloxz/imgurl": "= 2.31|<=2.31",
                 "hillelcoren/invoice-ninja": "<5.3.35",
@@ -6531,6 +6509,7 @@
                 "kevinpapst/kimai2": "<1.16.7",
                 "kitodo/presentation": "<3.1.2",
                 "klaviyo/magento2-extension": ">=1,<3",
+                "krayin/laravel-crm": "<1.2.2",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "la-haute-societe/tcpdf": "<6.2.22",
                 "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
@@ -6580,7 +6559,7 @@
                 "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
                 "nilsteampassnet/teampass": "<=2.1.27.36",
                 "noumo/easyii": "<=0.9",
-                "nukeviet/nukeviet": "<4.3.4",
+                "nukeviet/nukeviet": "<4.5.2",
                 "nystudio107/craft-seomatic": "<3.4.12",
                 "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
                 "october/backend": "<1.1.2",
@@ -6620,11 +6599,12 @@
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
                 "pimcore/data-hub": "<1.2.4",
-                "pimcore/pimcore": "<10.4",
+                "pimcore/pimcore": "<10.4.4",
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": ">= 4.0.0-BETA5, < 4.4.2|<4.2.10",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
+                "prestashop/blockwishlist": ">=2,<2.1.1",
                 "prestashop/contactform": ">1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
                 "prestashop/prestashop": ">=1.7,<=1.7.8.2",
@@ -6654,17 +6634,18 @@
                 "shopware/core": "<=6.4.9",
                 "shopware/platform": "<=6.4.9",
                 "shopware/production": "<=6.3.5.2",
-                "shopware/shopware": "<5.7.9",
+                "shopware/shopware": "<5.7.12",
                 "shopware/storefront": "<=6.4.8.1",
                 "shopxo/shopxo": "<2.2.6",
                 "showdoc/showdoc": "<2.10.4",
                 "silverstripe/admin": ">=1,<1.8.1",
-                "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
+                "silverstripe/assets": ">=1,<1.10.1",
                 "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
                 "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": "<4.10.1",
+                "silverstripe/framework": "<4.10.9",
                 "silverstripe/graphql": "<3.5.2|>=4-alpha.1,<4-alpha.2|= 4.0.0-alpha1",
+                "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
                 "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
                 "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
                 "silverstripe/silverstripe-omnipay": "<2.5.2|>=3,<3.0.2|>=3.1,<3.1.4|>=3.2,<3.2.1",
@@ -6737,6 +6718,7 @@
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
                 "thelia/thelia": ">=2.1-beta.1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
+                "thinkcmf/thinkcmf": "<=5.1.7",
                 "tinymce/tinymce": "<5.10",
                 "titon/framework": ">=0,<9.9.99",
                 "topthink/framework": "<6.0.12",
@@ -6745,9 +6727,9 @@
                 "tribalsystems/zenario": "<9.2.55826",
                 "truckersmp/phpwhois": "<=4.3.1",
                 "twig/twig": "<1.38|>=2,<2.14.11|>=3,<3.3.8",
-                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.19|>=11,<11.5",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.29|>=11,<11.5.11",
                 "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
-                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<=7.6.52|>=8,<=8.7.41|>=9,<9.5.29|>=10,<10.4.19|>=11,<11.5",
+                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<7.6.57|>=8,<8.7.47|>=9,<9.5.35|>=10,<10.4.29|>=11,<11.5.11",
                 "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
@@ -6845,7 +6827,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-08T23:04:00+00:00"
+            "time": "2022-06-29T23:04:12+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -7971,60 +7953,60 @@
         },
         {
             "name": "symplify/astral",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/astral.git",
-                "reference": "9fe2fea581ac43d709d29a6d32dca18b225061c9"
+                "reference": "5c00d67e177b3169b2f346d886e8237c6a2e8b6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/astral/zipball/9fe2fea581ac43d709d29a6d32dca18b225061c9",
-                "reference": "9fe2fea581ac43d709d29a6d32dca18b225061c9",
+                "url": "https://api.github.com/repos/symplify/astral/zipball/5c00d67e177b3169b2f346d886e8237c6a2e8b6d",
+                "reference": "5c00d67e177b3169b2f346d886e8237c6a2e8b6d",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "nikic/php-parser": "^4.14.0",
                 "php": ">=8.0",
-                "phpstan/phpdoc-parser": "^1.6.0",
-                "phpstan/phpstan": "^1.7.12",
+                "phpstan/phpdoc-parser": "^1.6.3",
+                "phpstan/phpstan": "^1.8",
                 "symfony/config": "^6.0",
                 "symfony/dependency-injection": "^6.0",
-                "symplify/package-builder": "^10.3",
-                "symplify/smart-file-system": "^10.3",
-                "symplify/symplify-kernel": "^10.3"
+                "symplify/package-builder": "^11.0.7",
+                "symplify/smart-file-system": "^11.0.7",
+                "symplify/symplify-kernel": "^11.0.7"
             },
             "conflict": {
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/composer-json-manipulator": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
+                "symplify/autowire-array-parameter": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/composer-json-manipulator": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/rule-doc-generator-contracts": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
                 "symplify/smart-file-system": "<9.4.70",
-                "symplify/symfony-static-dumper": "<10.3.0",
+                "symplify/symfony-static-dumper": "<11.0.7",
                 "symplify/symplify-kernel": "<9.4.70",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5",
-                "symplify/easy-testing": "^10.3"
+                "symplify/easy-testing": "^11.0.7"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -8043,7 +8025,7 @@
             ],
             "description": "Toolking for smart daily work with AST",
             "support": {
-                "source": "https://github.com/symplify/astral/tree/10.3.0"
+                "source": "https://github.com/symplify/astral/tree/11.0.7"
             },
             "funding": [
                 {
@@ -8055,49 +8037,49 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:14:03+00:00"
+            "time": "2022-07-04T21:51:28+00:00"
         },
         {
             "name": "symplify/coding-standard",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/coding-standard.git",
-                "reference": "873e1bf891960193177c87a2599c75273d7210f3"
+                "reference": "e634ce1573b0971b60f542352a96726974ee35e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/coding-standard/zipball/873e1bf891960193177c87a2599c75273d7210f3",
-                "reference": "873e1bf891960193177c87a2599c75273d7210f3",
+                "url": "https://api.github.com/repos/symplify/coding-standard/zipball/e634ce1573b0971b60f542352a96726974ee35e7",
+                "reference": "e634ce1573b0971b60f542352a96726974ee35e7",
                 "shasum": ""
             },
             "require": {
                 "friendsofphp/php-cs-fixer": "^3.8",
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symplify/autowire-array-parameter": "^10.3",
-                "symplify/package-builder": "^10.3",
-                "symplify/rule-doc-generator-contracts": "^10.3",
-                "symplify/symplify-kernel": "^10.3"
+                "symplify/autowire-array-parameter": "^11.0.7",
+                "symplify/package-builder": "^11.0.7",
+                "symplify/rule-doc-generator-contracts": "^11.0.7",
+                "symplify/symplify-kernel": "^11.0.7"
             },
             "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/composer-json-manipulator": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/smart-file-system": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/astral": "<11.0.7",
+                "symplify/composer-json-manipulator": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/smart-file-system": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "cweagans/composer-patches": "^1.7",
@@ -8106,15 +8088,15 @@
                 "nette/bootstrap": "^3.1",
                 "phpunit/phpunit": "^9.5",
                 "symfony/framework-bundle": "^6.0",
-                "symplify/easy-coding-standard": "^10.3",
-                "symplify/rule-doc-generator": "^10.3",
-                "symplify/smart-file-system": "^10.3",
-                "symplify/symplify-kernel": "^10.3"
+                "symplify/easy-coding-standard": "^11.0.7",
+                "symplify/rule-doc-generator": "^11.0.7",
+                "symplify/smart-file-system": "^11.0.7",
+                "symplify/symplify-kernel": "^11.0.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 },
                 "enable-patching": true,
                 "patches": {
@@ -8134,7 +8116,7 @@
             ],
             "description": "Set of Symplify rules for PHP_CodeSniffer and PHP CS Fixer.",
             "support": {
-                "source": "https://github.com/symplify/coding-standard/tree/10.3.0"
+                "source": "https://github.com/symplify/coding-standard/tree/11.0.7"
             },
             "funding": [
                 {
@@ -8146,7 +8128,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:14:04+00:00"
+            "time": "2022-07-04T21:51:25+00:00"
         },
         {
             "name": "symplify/easy-ci",
@@ -8154,12 +8136,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-ci.git",
-                "reference": "3591497150b5e4a7ac8792de3e1af7a7e1e13dcf"
+                "reference": "309ae1be235164861b86b55d041ff91203ff443f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-ci/zipball/3591497150b5e4a7ac8792de3e1af7a7e1e13dcf",
-                "reference": "3591497150b5e4a7ac8792de3e1af7a7e1e13dcf",
+                "url": "https://api.github.com/repos/symplify/easy-ci/zipball/309ae1be235164861b86b55d041ff91203ff443f",
+                "reference": "309ae1be235164861b86b55d041ff91203ff443f",
                 "shasum": ""
             },
             "require": {
@@ -8188,20 +8170,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:15:25+00:00"
+            "time": "2022-07-04T21:52:40+00:00"
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-coding-standard.git",
-                "reference": "65a8f62fff719d5d70b3b71c0c2b220c17877110"
+                "reference": "d60bb2263932caad6f5bf5a648bb79aa3c4c5f1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/65a8f62fff719d5d70b3b71c0c2b220c17877110",
-                "reference": "65a8f62fff719d5d70b3b71c0c2b220c17877110",
+                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/d60bb2263932caad6f5bf5a648bb79aa3c4c5f1e",
+                "reference": "d60bb2263932caad6f5bf5a648bb79aa3c4c5f1e",
                 "shasum": ""
             },
             "require": {
@@ -8231,7 +8213,7 @@
             ],
             "description": "Prefixed scoped version of ECS package",
             "support": {
-                "source": "https://github.com/symplify/easy-coding-standard/tree/10.3.0"
+                "source": "https://github.com/symplify/easy-coding-standard/tree/11.0.7"
             },
             "funding": [
                 {
@@ -8243,48 +8225,48 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:15:55+00:00"
+            "time": "2022-07-04T21:53:21+00:00"
         },
         {
             "name": "symplify/phpstan-extensions",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/phpstan-extensions.git",
-                "reference": "dc75073308e689b899adc22e6bd9baed6e1b7e7a"
+                "reference": "95cadbf2dff42370f4247c125118efb67d2a54d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/phpstan-extensions/zipball/dc75073308e689b899adc22e6bd9baed6e1b7e7a",
-                "reference": "dc75073308e689b899adc22e6bd9baed6e1b7e7a",
+                "url": "https://api.github.com/repos/symplify/phpstan-extensions/zipball/95cadbf2dff42370f4247c125118efb67d2a54d5",
+                "reference": "95cadbf2dff42370f4247c125118efb67d2a54d5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
-                "phpstan/phpstan": "^1.7.12",
-                "symplify/astral": "^10.3",
-                "symplify/package-builder": "^10.3",
-                "symplify/smart-file-system": "^10.3"
+                "phpstan/phpstan": "^1.8",
+                "symplify/astral": "^11.0.7",
+                "symplify/package-builder": "^11.0.7",
+                "symplify/smart-file-system": "^11.0.7"
             },
             "conflict": {
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/composer-json-manipulator": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/rule-doc-generator-contracts": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/symplify-kernel": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/autowire-array-parameter": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/composer-json-manipulator": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/rule-doc-generator-contracts": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/symplify-kernel": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -8292,7 +8274,7 @@
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -8311,7 +8293,7 @@
             ],
             "description": "Pre-escaped error messages in 'symplify' error format, container aware test case and other useful extensions for PHPStan",
             "support": {
-                "source": "https://github.com/symplify/phpstan-extensions/tree/10.3.0"
+                "source": "https://github.com/symplify/phpstan-extensions/tree/11.0.7"
             },
             "funding": [
                 {
@@ -8323,82 +8305,81 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:15:08+00:00"
+            "time": "2022-07-04T21:52:36+00:00"
         },
         {
             "name": "symplify/phpstan-rules",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/phpstan-rules.git",
-                "reference": "a068c8cebcffad15a0c2aa9a583141c43927f47b"
+                "reference": "5a31c14603324e5fa07219fd3a81058bb6097b39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/phpstan-rules/zipball/a068c8cebcffad15a0c2aa9a583141c43927f47b",
-                "reference": "a068c8cebcffad15a0c2aa9a583141c43927f47b",
+                "url": "https://api.github.com/repos/symplify/phpstan-rules/zipball/5a31c14603324e5fa07219fd3a81058bb6097b39",
+                "reference": "5a31c14603324e5fa07219fd3a81058bb6097b39",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "nikic/php-parser": "^4.14.0",
                 "php": ">=8.0",
-                "phpstan/phpdoc-parser": "^1.6.0",
-                "phpstan/phpstan": "^1.7.12",
-                "symplify/astral": "^10.3",
-                "symplify/composer-json-manipulator": "^10.3",
-                "symplify/package-builder": "^10.3",
-                "symplify/rule-doc-generator-contracts": "^10.3",
-                "symplify/smart-file-system": "^10.3",
+                "phpstan/phpdoc-parser": "^1.6.3",
+                "phpstan/phpstan": "^1.8",
+                "symplify/astral": "^11.0.7",
+                "symplify/composer-json-manipulator": "^11.0.7",
+                "symplify/package-builder": "^11.0.7",
+                "symplify/rule-doc-generator-contracts": "^11.0.7",
+                "symplify/smart-file-system": "^11.0.7",
                 "webmozart/assert": "^1.10"
             },
             "conflict": {
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/symplify-kernel": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/autowire-array-parameter": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/symplify-kernel": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "require-dev": {
                 "myclabs/php-enum": "^1.8",
                 "phpunit/phpunit": "^9.5",
                 "symfony/framework-bundle": "^6.0",
-                "symplify/easy-testing": "^10.3",
-                "symplify/phpstan-extensions": "^10.3",
-                "symplify/rule-doc-generator": "^10.3"
+                "symplify/easy-testing": "^11.0.7",
+                "symplify/phpstan-extensions": "^11.0.7",
+                "symplify/rule-doc-generator": "^11.0.7"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 },
                 "phpstan": {
                     "includes": [
                         "config/services/services.neon",
-                        "packages/cognitive-complexity/config/cognitive-complexity-services.neon",
-                        "packages/symfony/config/services.neon",
-                        "packages/nette/config/services.neon"
+                        "config/packages/cognitive-complexity/cognitive-complexity-services.neon",
+                        "config/packages/symfony/services.neon",
+                        "config/packages/nette/services.neon"
                     ]
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symplify\\PHPStanRules\\": "src",
-                    "Symplify\\PHPStanRules\\Nette\\": "packages/nette/src",
-                    "Symplify\\PHPStanRules\\Symfony\\": "packages/symfony/src",
-                    "Symplify\\PHPStanRules\\ObjectCalisthenics\\": "packages/object-calisthenics/src",
-                    "Symplify\\PHPStanRules\\CognitiveComplexity\\": "packages/cognitive-complexity/src"
+                    "Symplify\\PHPStanRules\\": [
+                        "src",
+                        "packages"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -8407,7 +8388,7 @@
             ],
             "description": "Set of Symplify rules for PHPStan",
             "support": {
-                "source": "https://github.com/symplify/phpstan-rules/tree/10.3.0"
+                "source": "https://github.com/symplify/phpstan-rules/tree/11.0.7"
             },
             "funding": [
                 {
@@ -8419,20 +8400,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:14:44+00:00"
+            "time": "2022-07-04T21:52:39+00:00"
         },
         {
             "name": "symplify/rule-doc-generator-contracts",
-            "version": "10.3.0",
+            "version": "11.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/rule-doc-generator-contracts.git",
-                "reference": "f18815a7558ef5905a2581d8cca54a3601584b2d"
+                "reference": "90323f87543ac36a29c78e3f0810e9e3f34f1379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/f18815a7558ef5905a2581d8cca54a3601584b2d",
-                "reference": "f18815a7558ef5905a2581d8cca54a3601584b2d",
+                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/90323f87543ac36a29c78e3f0810e9e3f34f1379",
+                "reference": "90323f87543ac36a29c78e3f0810e9e3f34f1379",
                 "shasum": ""
             },
             "require": {
@@ -8440,32 +8421,32 @@
                 "php": ">=8.0"
             },
             "conflict": {
-                "symplify/astral": "<10.3.0",
-                "symplify/autowire-array-parameter": "<10.3.0",
-                "symplify/coding-standard": "<10.3.0",
-                "symplify/composer-json-manipulator": "<10.3.0",
-                "symplify/config-transformer": "<10.3.0",
-                "symplify/easy-ci": "<10.3.0",
-                "symplify/easy-coding-standard": "<10.3.0",
-                "symplify/easy-parallel": "<10.3.0",
-                "symplify/easy-testing": "<10.3.0",
-                "symplify/monorepo-builder": "<10.3.0",
-                "symplify/neon-config-dumper": "<10.3.0",
-                "symplify/package-builder": "<10.3.0",
-                "symplify/php-config-printer": "<10.3.0",
-                "symplify/phpstan-extensions": "<10.3.0",
-                "symplify/phpstan-rules": "<10.3.0",
-                "symplify/rule-doc-generator": "<10.3.0",
-                "symplify/skipper": "<10.3.0",
-                "symplify/smart-file-system": "<10.3.0",
-                "symplify/symfony-static-dumper": "<10.3.0",
-                "symplify/symplify-kernel": "<10.3.0",
-                "symplify/vendor-patches": "<10.3.0"
+                "symplify/astral": "<11.0.7",
+                "symplify/autowire-array-parameter": "<11.0.7",
+                "symplify/coding-standard": "<11.0.7",
+                "symplify/composer-json-manipulator": "<11.0.7",
+                "symplify/config-transformer": "<11.0.7",
+                "symplify/easy-ci": "<11.0.7",
+                "symplify/easy-coding-standard": "<11.0.7",
+                "symplify/easy-parallel": "<11.0.7",
+                "symplify/easy-testing": "<11.0.7",
+                "symplify/monorepo-builder": "<11.0.7",
+                "symplify/neon-config-dumper": "<11.0.7",
+                "symplify/package-builder": "<11.0.7",
+                "symplify/php-config-printer": "<11.0.7",
+                "symplify/phpstan-extensions": "<11.0.7",
+                "symplify/phpstan-rules": "<11.0.7",
+                "symplify/rule-doc-generator": "<11.0.7",
+                "symplify/skipper": "<11.0.7",
+                "symplify/smart-file-system": "<11.0.7",
+                "symplify/symfony-static-dumper": "<11.0.7",
+                "symplify/symplify-kernel": "<11.0.7",
+                "symplify/vendor-patches": "<11.0.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.3-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -8479,7 +8460,7 @@
             ],
             "description": "Contracts for production code of RuleDocGenerator",
             "support": {
-                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/10.3.0"
+                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/11.0.7"
             },
             "funding": [
                 {
@@ -8491,7 +8472,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T23:15:12+00:00"
+            "time": "2022-07-04T21:52:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc51d28bfc24783a24cfd8fddd290dd7",
+    "content-hash": "3f7b7fdb56c93fc0aa494c3741eb7512",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -8525,7 +8525,14 @@
             "time": "2021-07-28T10:34:58+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "symplify/amnesia",
+            "version": "10.2.7.0",
+            "alias": "11.0",
+            "alias_normalized": "11.0.0.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
         "rector/rector": 20,


### PR DESCRIPTION
@TomasVotruba the current daily PR got error:

```bash
Run composer update rector/rector phpstan/phpdoc-parser --with-all-dependencies
Loading composer repositories with package information
Info from [https://repo.packagist.org:](https://repo.packagist.org/) #StandWithUkraine
Updating dependencies
Your requirements could not be resolved to an installable set of packages.
Error: Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Root composer.json requires symplify/amnesia ^11.0, found symplify/amnesia[dev-main, 9.0.39, ..., 9.4.70, 10.0.0-beta1, ..., 10.3.x-dev (alias of dev-main)] but it does not match the constraint.
```

because symplify/amnesia:^11.0 is not exists. I updated to "10.2.7 as 11.0" for latest release for it.

Fixes https://github.com/rectorphp/getrector.org/issues/628