### PR TITLE
Make daily pull request per 6 hours

### DIFF
--- a/.github/workflows/daily_pull_request_automatic_update.yaml
+++ b/.github/workflows/daily_pull_request_automatic_update.yaml
@@ -2,8 +2,8 @@ name: Daily Pull Request Automatic Update
 
 on:
     schedule:
-        # https://crontab.guru/every-day
-        -   cron: "0 0 * * *"
+        # https://crontab.guru/every-6-hours
+        -   cron: "0 */6 * * *"
 
 env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361


### PR DESCRIPTION
The deployment in getrector.org is already per-6 hours: 00:05, 06:05, 12:05, 18:05.

This PR update the daily Update Rector Dependencies per 00:00, 06:00, 12:00, 18:00.

The 5 minutes different is to ensure PR merged first.