### PR TITLE
Revert "add subdomains directory to .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,3 @@ yarn-error.log
 /demo-runner
 
 data/json-database/*
-
-/subdomains


### PR DESCRIPTION
Reverts rectorphp/getrector.org#712

subdomain now can live outside root website.