### PR TITLE
[Test] Using yarn build instead of yarn run dev for acceptance test

### DIFF
--- a/.github/workflows/acceptance_test.yaml
+++ b/.github/workflows/acceptance_test.yaml
@@ -21,6 +21,6 @@ jobs:
             -   run: php -S localhost:8080 --docroot public &>/dev/null&
 
             -   run: yarn install
-            -   run: yarn run dev
+            -   run: yarn build
             -   run: cp .env_acceptance.dist .env
             -   run: vendor/bin/codecept run Acceptance


### PR DESCRIPTION
To ensure it mimic the production build which the scripts (css and js) are minified.