### PR TITLE
Fix docs rector rules list URL

### DIFF
--- a/data/docs/custom-rule.md
+++ b/data/docs/custom-rule.md
@@ -1,4 +1,4 @@
-First, make sure it's not covered by [any existing Rectors](/docs/rector_rules_overview.md).
+First, make sure it's not covered by [any existing Rectors](https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md).
 Let's say we want to **change method calls from `set*` to `change*`**.
 
 ```diff


### PR DESCRIPTION
Currently got 404 due to relative path that goes to https://getrector.org/docs/rector_rules_overview.md