### PR TITLE
Fix final config suggestion

### DIFF
--- a/data/blog/posts/2022/2022-07-04-how-to-automatically-add-return-type-declarations-without-breaking-your-code.md
+++ b/data/blog/posts/2022/2022-07-04-how-to-automatically-add-return-type-declarations-without-breaking-your-code.md
@@ -168,6 +168,8 @@ Depending on what age your project is coming from, there is one requirement to m
 Rector can handles some case above in the basic version. Add these rules to your code and see for yourself:
 
 ```php
+<?php 
+
 use Rector\Config\RectorConfig;
 use Rector\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
@@ -177,6 +179,7 @@ return static function (RectorConfig $rectorConfig): void {
         ReturnTypeFromStrictNativeCallRector::class,
         ReturnTypeFromStrictScalarReturnExprRector::class,
     ]);
+};
 ```
 
 Run Rector and see how many new types were added. In the project we tested these rules on, we had over 40 changed files in the first run. From zero to 40 files, quite impressive. And as you know, strict types [spread exponentially](/blog/2021/02/15/how-much-does-single-type-declaration-know).


### PR DESCRIPTION
This fixes the suggested config by adding the missing opening tag and the missing closing bracket and semi-colon. Now if the example is copied and pasted into a `rector.php` file it works straight out of the box.