### PR TITLE
fix: [Docs][TeamTools] Since StringExtensionToConfigBuilderRector is deprecated this section is no longer relevant

### DIFF
--- a/resources/docs/team-tools.md
+++ b/resources/docs/team-tools.md
@@ -22,7 +22,3 @@ There 2 more tools that help out with specific sets:
 
 * [tomasvotruba/type-coverage](https://github.com/TomasVotruba/type-coverage) - works best with `withTypeCoverageLevel()`
 * [tomasvotruba/class-leak](https://github.com/TomasVotruba/class-leak) - works best with `withDeadCodeLevel()`
-
-<br>
-
-There is also [symplify/config-transformer](https://github.com/symplify/config-transformer) that helps with transforming YAML Symfony configs to PHP. There you can follow up with [Symfony rules for Rector](/rule-detail/string-extension-to-config-builder-rector) to reach config builders.


### PR DESCRIPTION
Hi Everyone ! 

This PR removes a section of the documentation that referred to a rule now deprecated since [this PR](https://github.com/rectorphp/rector-symfony/pull/854)￼.
As the rule no longer works, it doesn’t make sense to keep it documented.

I’d also like to thank the Rector community for everything they bring to the PHP ecosystem — truly impressive work.
I found the arguments for moving from YAML to PHP configuration very compelling, and I'm sad that this approach is no longer supported.