### PR TITLE
Rename `maxNumberOfProcesses` -> `maxNumberOfProcess`

### DIFF
--- a/resources/docs/config-configuration.md
+++ b/resources/docs/config-configuration.md
@@ -167,7 +167,7 @@ use Rector\Config\RectorConfig;
 return RectorConfig::configure()
     ->withParallel(
         timeoutSeconds: 600,
-        maxNumberOfProcesses: 8,
+        maxNumberOfProcess: 8,
         jobSize: 20,
     );
 ```


### PR DESCRIPTION
In the codebase this argument is `maxNumberOfProcess`. 

https://github.com/rectorphp/rector/blob/8268abaeb93c70c445cef8d4d6cbc76997c39350/src/Config/RectorConfig.php#L84

If you copy and paste this code block it does not run without modification.